### PR TITLE
Add Claude Opus 4.6 model to available options

### DIFF
--- a/content/helpers/claude-api.js
+++ b/content/helpers/claude-api.js
@@ -1460,6 +1460,7 @@ async function isLikelyTextFile(file) {
 }
 
 const CLAUDE_MODELS = [
+	{ value: 'claude-opus-4-6', label: 'Opus 4.6' },
 	{ value: 'claude-opus-4-5-20251101', label: 'Opus 4.5' },
 	{ value: 'claude-sonnet-4-5-20250929', label: 'Sonnet 4.5' },
 	{ value: 'claude-opus-4-1-20250805', label: 'Opus 4.1' },


### PR DESCRIPTION
## Summary
Added support for the new Claude Opus 4.6 model to the list of available Claude models.

## Changes
- Added `claude-opus-4-6` (Opus 4.6) as the first option in the `CLAUDE_MODELS` array, making it the default model selection

## Details
The new Opus 4.6 model is now available for users to select when interacting with Claude through this application. It appears at the top of the model list, positioning it as the latest and preferred option.

https://claude.ai/code/session_018LRSWcRZm2vmy5bUBP37HX