### PR TITLE
added prompt template library with variable insertion

### DIFF
--- a/content/helpers/claude-styles.js
+++ b/content/helpers/claude-styles.js
@@ -1081,6 +1081,7 @@ const ButtonBar = {
 	BUTTON_PRIORITY: [
 		'search-button',
 		'navigation-button',
+		'prompt-templates-button',
 		'style-selector-button',
 		'preset-switcher-button',
 		'export-button',

--- a/content/helpers/settings.js
+++ b/content/helpers/settings.js
@@ -53,6 +53,9 @@ const SETTINGS_KEYS = {
 	PREF_SWITCHER: {
 		PRESETS: { key: 'preference_presets', default: {}, type: 'object' },
 	},
+	TEMPLATES: {
+		LIBRARY: { key: 'prompt_templates', default: {}, type: 'object' },
+	},
 };
 
 // ======== WORLD DETECTION ========

--- a/content/isolated/prompt-templates.js
+++ b/content/isolated/prompt-templates.js
@@ -1,0 +1,476 @@
+// prompt-templates.js
+(function () {
+	'use strict';
+
+	const TEMPLATES_KEY = SETTINGS_KEYS.TEMPLATES.LIBRARY;
+	const TEMPLATE_BUTTON_CLASS = 'prompt-templates-button';
+	const TEMPLATE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>`;
+	const PLACEHOLDER_REGEX = /\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/g;
+
+	function nowTs() {
+		return Date.now();
+	}
+
+	function makeId() {
+		return `tpl_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+	}
+
+	function normalizeName(name) {
+		return (name || '').trim().toLowerCase();
+	}
+
+	function sanitizeTemplate(item) {
+		if (!item || typeof item !== 'object') return null;
+		const id = typeof item.id === 'string' && item.id ? item.id : makeId();
+		const name = typeof item.name === 'string' ? item.name.trim() : '';
+		const content = typeof item.content === 'string' ? item.content : '';
+		if (!name || !content.trim()) return null;
+		return {
+			id,
+			name,
+			content,
+			tags: Array.isArray(item.tags) ? item.tags.filter(t => typeof t === 'string') : [],
+			createdAt: typeof item.createdAt === 'number' ? item.createdAt : nowTs(),
+			updatedAt: typeof item.updatedAt === 'number' ? item.updatedAt : nowTs(),
+			lastUsedAt: typeof item.lastUsedAt === 'number' ? item.lastUsedAt : 0,
+			usageCount: typeof item.usageCount === 'number' ? item.usageCount : 0,
+		};
+	}
+
+	async function getTemplatesMap() {
+		const raw = await settingsRegistry.get(TEMPLATES_KEY);
+		if (!raw || typeof raw !== 'object') return {};
+		const cleaned = {};
+		for (const [id, item] of Object.entries(raw)) {
+			const normalized = sanitizeTemplate({ ...item, id });
+			if (normalized) cleaned[normalized.id] = normalized;
+		}
+		return cleaned;
+	}
+
+	async function saveTemplatesMap(map) {
+		await settingsRegistry.set(TEMPLATES_KEY, map);
+	}
+
+	function sortTemplates(items) {
+		return items.sort((a, b) => {
+			const lastUsedDiff = (b.lastUsedAt || 0) - (a.lastUsedAt || 0);
+			if (lastUsedDiff !== 0) return lastUsedDiff;
+			const usageDiff = (b.usageCount || 0) - (a.usageCount || 0);
+			if (usageDiff !== 0) return usageDiff;
+			return a.name.localeCompare(b.name);
+		});
+	}
+
+	function extractVariables(content) {
+		const vars = [];
+		const seen = new Set();
+		let match;
+		while ((match = PLACEHOLDER_REGEX.exec(content)) !== null) {
+			const key = match[1].trim();
+			const normalized = key.toLowerCase();
+			if (!seen.has(normalized)) {
+				seen.add(normalized);
+				vars.push(key);
+			}
+		}
+		PLACEHOLDER_REGEX.lastIndex = 0;
+		return vars;
+	}
+
+	function renderTemplate(content, values) {
+		return content.replace(PLACEHOLDER_REGEX, (_, key) => {
+			const value = values[key] ?? values[key.toLowerCase()] ?? '';
+			return String(value);
+		});
+	}
+
+	async function saveTemplate(input, originalId = null) {
+		const map = await getTemplatesMap();
+		const name = (input.name || '').trim();
+		const content = input.content || '';
+		if (!name) throw new Error('Template name is required.');
+		if (!content.trim()) throw new Error('Template content is required.');
+
+		const normalized = normalizeName(name);
+		for (const tpl of Object.values(map)) {
+			if (tpl.id !== originalId && normalizeName(tpl.name) === normalized) {
+				throw new Error('A template with this name already exists.');
+			}
+		}
+
+		const id = originalId || makeId();
+		const existing = map[id];
+		map[id] = sanitizeTemplate({
+			id,
+			name,
+			content,
+			tags: input.tags || existing?.tags || [],
+			createdAt: existing?.createdAt || nowTs(),
+			updatedAt: nowTs(),
+			lastUsedAt: existing?.lastUsedAt || 0,
+			usageCount: existing?.usageCount || 0,
+		});
+		await saveTemplatesMap(map);
+		return map[id];
+	}
+
+	async function deleteTemplate(id) {
+		const map = await getTemplatesMap();
+		delete map[id];
+		await saveTemplatesMap(map);
+	}
+
+	async function touchTemplateUsage(id) {
+		const map = await getTemplatesMap();
+		const tpl = map[id];
+		if (!tpl) return;
+		tpl.lastUsedAt = nowTs();
+		tpl.usageCount = (tpl.usageCount || 0) + 1;
+		tpl.updatedAt = nowTs();
+		await saveTemplatesMap(map);
+	}
+
+	function findComposerInput() {
+		const selectors = [
+			'textarea[placeholder*="Message"]',
+			'textarea[data-testid*="chat"]',
+			'textarea',
+			'div[contenteditable="true"][role="textbox"]',
+			'div[contenteditable="true"]',
+		];
+		for (const selector of selectors) {
+			const nodes = Array.from(document.querySelectorAll(selector));
+			const node = nodes.find(el => el.offsetParent !== null && !el.closest('[aria-hidden="true"]'));
+			if (node) return node;
+		}
+		return null;
+	}
+
+	function setComposerText(target, textToInsert) {
+		if (!target) return false;
+		const isTextArea = target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement;
+		if (isTextArea) {
+			const current = target.value || '';
+			const sep = current.trim().length ? '\n\n' : '';
+			target.value = `${current}${sep}${textToInsert}`;
+			target.dispatchEvent(new Event('input', { bubbles: true }));
+			target.dispatchEvent(new Event('change', { bubbles: true }));
+			target.focus();
+			return true;
+		}
+
+		if (target.isContentEditable) {
+			const current = target.innerText || '';
+			const sep = current.trim().length ? '\n\n' : '';
+			target.innerText = `${current}${sep}${textToInsert}`;
+			target.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: textToInsert }));
+			target.focus();
+			return true;
+		}
+
+		return false;
+	}
+
+	async function insertTemplateIntoComposer(template) {
+		const vars = extractVariables(template.content);
+		let finalText = template.content;
+		if (vars.length > 0) {
+			const values = await showVariableModal(template.name, vars);
+			if (!values) return false;
+			finalText = renderTemplate(template.content, values);
+		}
+
+		const composer = findComposerInput();
+		if (!composer) {
+			await showClaudeAlert('Error', 'Could not find message input.');
+			return false;
+		}
+
+		const ok = setComposerText(composer, finalText);
+		if (!ok) {
+			await showClaudeAlert('Error', 'Could not insert into message input.');
+			return false;
+		}
+
+		await touchTemplateUsage(template.id);
+		await showClaudeAlert('Prompt templates', `Inserted "${template.name}".`);
+		return true;
+	}
+
+	async function showVariableModal(templateName, variables) {
+		return new Promise((resolve) => {
+			const root = document.createElement('div');
+			root.className = 'space-y-3';
+			const inputs = {};
+
+			for (const key of variables) {
+				const wrap = document.createElement('div');
+				const label = document.createElement('label');
+				label.className = CLAUDE_CLASSES.LABEL;
+				label.textContent = key;
+				const input = createClaudeInput({ type: 'text', placeholder: `Value for ${key}` });
+				inputs[key] = input;
+				wrap.appendChild(label);
+				wrap.appendChild(input);
+				root.appendChild(wrap);
+			}
+
+			const modal = new ClaudeModal(`Fill variables: ${templateName}`, root, false);
+			modal.addCancel('Cancel', () => resolve(null));
+			modal.addConfirm('Insert', () => {
+				const values = {};
+				for (const [key, input] of Object.entries(inputs)) {
+					values[key] = input.value || '';
+				}
+				resolve(values);
+			});
+			modal.show();
+		});
+	}
+
+	function createTemplateEditorElement(initial = null) {
+		const wrapper = document.createElement('div');
+		wrapper.className = 'space-y-3';
+
+		const nameWrap = document.createElement('div');
+		const nameLabel = document.createElement('label');
+		nameLabel.className = CLAUDE_CLASSES.LABEL;
+		nameLabel.textContent = 'Template name';
+		const nameInput = createClaudeInput({ type: 'text', value: initial?.name || '', placeholder: 'e.g., Bug triage prompt' });
+		nameWrap.appendChild(nameLabel);
+		nameWrap.appendChild(nameInput);
+
+		const contentWrap = document.createElement('div');
+		const contentLabel = document.createElement('label');
+		contentLabel.className = CLAUDE_CLASSES.LABEL;
+		contentLabel.textContent = 'Template content';
+		const contentInput = document.createElement('textarea');
+		contentInput.className = `${CLAUDE_CLASSES.INPUT} min-h-32`;
+		contentInput.rows = 8;
+		contentInput.placeholder = 'Use {{variable_name}} placeholders if needed.';
+		contentInput.value = initial?.content || '';
+		contentWrap.appendChild(contentLabel);
+		contentWrap.appendChild(contentInput);
+
+		const hint = document.createElement('p');
+		hint.className = CLAUDE_CLASSES.TEXT_MUTED;
+		hint.textContent = 'Variables format: {{topic}}, {{tone}}, {{audience}}';
+
+		wrapper.appendChild(nameWrap);
+		wrapper.appendChild(contentWrap);
+		wrapper.appendChild(hint);
+
+		return { wrapper, nameInput, contentInput };
+	}
+
+	async function showTemplateEditorModal(existing = null) {
+		return new Promise((resolve) => {
+			const ui = createTemplateEditorElement(existing);
+			const modal = new ClaudeModal(existing ? 'Edit template' : 'New template', ui.wrapper, false);
+			modal.addCancel('Cancel', () => resolve(false));
+			modal.addConfirm(existing ? 'Save' : 'Create', async () => {
+				try {
+					await saveTemplate({
+						name: ui.nameInput.value,
+						content: ui.contentInput.value,
+					}, existing?.id || null);
+					resolve(true);
+				} catch (error) {
+					await showClaudeAlert('Validation error', error.message || 'Failed to save template.');
+					return false;
+				}
+				return true;
+			});
+			modal.show();
+		});
+	}
+
+	function createTemplateRow(template, refresh, options = {}) {
+		const { onInserted = null } = options;
+		const row = document.createElement('div');
+		row.className = 'p-3 rounded bg-bg-200 border border-border-300 space-y-2';
+
+		const top = document.createElement('div');
+		top.className = 'flex items-center justify-between gap-2';
+		const title = document.createElement('div');
+		title.className = 'text-text-100 font-medium';
+		title.textContent = template.name;
+		const actions = document.createElement('div');
+		actions.className = 'flex gap-2';
+
+		const insertBtn = createClaudeButton('Insert', 'primary', async () => {
+			const inserted = await insertTemplateIntoComposer(template);
+			if (inserted && typeof onInserted === 'function') {
+				onInserted();
+			}
+		});
+		const editBtn = createClaudeButton('Edit', 'secondary', async () => {
+			const changed = await showTemplateEditorModal(template);
+			if (changed) await refresh();
+		});
+		const deleteBtn = createClaudeButton('Delete', 'secondary', async () => {
+			const confirmed = await showClaudeConfirm('Delete template', `Delete "${template.name}"?`);
+			if (!confirmed) return;
+			await deleteTemplate(template.id);
+			await refresh();
+		});
+
+		actions.appendChild(insertBtn);
+		actions.appendChild(editBtn);
+		actions.appendChild(deleteBtn);
+		top.appendChild(title);
+		top.appendChild(actions);
+
+		const preview = document.createElement('div');
+		preview.className = 'text-sm text-text-300';
+		preview.textContent = template.content.length > 180
+			? `${template.content.slice(0, 180)}...`
+			: template.content;
+
+		row.appendChild(top);
+		row.appendChild(preview);
+		return row;
+	}
+
+	async function showTemplatePickerModal() {
+		const root = document.createElement('div');
+		root.className = 'space-y-3';
+
+		const search = createClaudeInput({ type: 'text', placeholder: 'Search templates...' });
+		const list = document.createElement('div');
+		list.className = 'max-h-[50vh] overflow-y-auto space-y-2';
+
+		const modal = new ClaudeModal('Prompt Templates', root);
+		modal.modal.classList.remove('max-w-md');
+		modal.modal.classList.add('max-w-3xl');
+		modal.addCancel('Close');
+		modal.addConfirm('New template', async () => {
+			const created = await showTemplateEditorModal();
+			if (created) await refresh();
+			return false;
+		}, false);
+
+		root.appendChild(search);
+		root.appendChild(list);
+
+		const refresh = async () => {
+			const query = (search.value || '').trim().toLowerCase();
+			const templates = sortTemplates(Object.values(await getTemplatesMap()));
+			list.innerHTML = '';
+
+			const filtered = templates.filter(t => {
+				if (!query) return true;
+				return t.name.toLowerCase().includes(query) || t.content.toLowerCase().includes(query);
+			});
+
+			if (filtered.length === 0) {
+				const empty = document.createElement('div');
+				empty.className = 'text-text-400 text-sm py-4 text-center';
+				empty.textContent = query ? 'No templates match your search.' : 'No templates yet. Create one to get started.';
+				list.appendChild(empty);
+				return;
+			}
+
+			filtered.forEach(t => list.appendChild(createTemplateRow(t, refresh, {
+				onInserted: () => modal.destroy(),
+			})));
+		};
+
+		search.addEventListener('input', refresh);
+		await refresh();
+		modal.show();
+	}
+
+	function createTemplateButton() {
+		const button = createClaudeButton(TEMPLATE_ICON_SVG, 'icon');
+		button.classList.add('shrink-0');
+		button.onclick = async () => {
+			await showTemplatePickerModal();
+		};
+		return button;
+	}
+
+	async function findSettingsTextarea() {
+		const textarea = document.getElementById('conversation-preferences');
+		if (!textarea) return null;
+		const container = textarea.closest('.group.relative');
+		if (!container || container.dataset.templatesManagerProcessed) return null;
+		return { container };
+	}
+
+	function createSettingsManagerUI() {
+		const root = document.createElement('div');
+		root.className = 'prompt-template-settings mb-4';
+		root.innerHTML = `
+			<div class="flex items-center justify-between mb-2">
+				<label class="${CLAUDE_CLASSES.LABEL} mb-0">Prompt templates</label>
+				<button class="new-template-btn ${CLAUDE_CLASSES.BTN_SECONDARY}">New Template</button>
+			</div>
+			<input class="${CLAUDE_CLASSES.INPUT} template-search mb-3" placeholder="Search templates..." />
+			<div class="template-list max-h-[45vh] overflow-y-auto space-y-2"></div>
+		`;
+		return root;
+	}
+
+	async function renderSettingsTemplateList(root) {
+		const list = root.querySelector('.template-list');
+		const query = (root.querySelector('.template-search').value || '').trim().toLowerCase();
+		const templates = sortTemplates(Object.values(await getTemplatesMap()));
+		list.innerHTML = '';
+
+		const filtered = templates.filter(t => !query
+			|| t.name.toLowerCase().includes(query)
+			|| t.content.toLowerCase().includes(query));
+
+		if (filtered.length === 0) {
+			const empty = document.createElement('div');
+			empty.className = 'text-text-400 text-sm py-4 text-center';
+			empty.textContent = query ? 'No matches.' : 'No templates created yet.';
+			list.appendChild(empty);
+			return;
+		}
+
+		const refresh = async () => renderSettingsTemplateList(root);
+		filtered.forEach(t => list.appendChild(createTemplateRow(t, refresh)));
+	}
+
+	async function attachSettingsManagerHandlers(root) {
+		root.querySelector('.new-template-btn').addEventListener('click', async () => {
+			const created = await showTemplateEditorModal();
+			if (created) await renderSettingsTemplateList(root);
+		});
+
+		root.querySelector('.template-search').addEventListener('input', async () => {
+			await renderSettingsTemplateList(root);
+		});
+
+		await renderSettingsTemplateList(root);
+	}
+
+	async function tryInjectSettingsUI() {
+		const elements = await findSettingsTextarea();
+		if (!elements) return;
+		const { container } = elements;
+
+		const manager = createSettingsManagerUI();
+		await attachSettingsManagerHandlers(manager);
+		container.parentNode.insertBefore(manager, container);
+		container.dataset.templatesManagerProcessed = 'true';
+	}
+
+	function initialize() {
+		ButtonBar.register({
+			buttonClass: TEMPLATE_BUTTON_CLASS,
+			createFn: createTemplateButton,
+			tooltip: 'Prompt templates',
+			forceDisplayOnMobile: false,
+			pages: ['chat', 'home', 'coworkChat', 'coworkHome'],
+		});
+
+		tryInjectSettingsUI();
+		setInterval(tryInjectSettingsUI, 1000);
+	}
+
+	setTimeout(initialize);
+})();

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -35,6 +35,7 @@
 				"content/isolated/pref-switcher.js",
 				"content/isolated/stt.js",
 				"content/isolated/perchat-styles.js",
+				"content/isolated/prompt-templates.js",
 				"content/isolated/tts.js",
 				"content/isolated/exporter.js",
 				"content/isolated/notifications.js"

--- a/manifest_electron.json
+++ b/manifest_electron.json
@@ -35,6 +35,7 @@
 				"content/isolated/pref-switcher.js",
 				"content/isolated/stt.js",
 				"content/isolated/perchat-styles.js",
+				"content/isolated/prompt-templates.js",
 				"content/isolated/tts.js",
 				"content/isolated/exporter.js",
 				"content/isolated/notifications.js"

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -35,6 +35,7 @@
 				"content/isolated/pref-switcher.js",
 				"content/isolated/stt.js",
 				"content/isolated/perchat-styles.js",
+				"content/isolated/prompt-templates.js",
 				"content/isolated/tts.js",
 				"content/isolated/exporter.js",
 				"content/isolated/notifications.js"


### PR DESCRIPTION
# Added Prompt Template Library - Changes Implemented

## Overview

Implemented a complete Prompt Template Library feature for Claude QoL, including storage, UI, insertion flow, variable substitution, and cross-manifest integration.

## What Was Added

### 1) New settings key for templates
- Updated `content/helpers/settings.js`
- Added:
  - `SETTINGS_KEYS.TEMPLATES.LIBRARY`
  - Storage key: `prompt_templates`
  - Default value: `{}`

### 2) New isolated feature module
- Added new file: `content/isolated/prompt-templates.js`
- Core capabilities:
  - Template CRUD (create, edit, delete, list)
  - Persistent storage via `settingsRegistry`
  - Name uniqueness validation (case-insensitive)
  - Sanitization of stored template objects
  - Usage tracking (`lastUsedAt`, `usageCount`)
  - Search and ranking in picker:
    1. Most recently used
    2. Highest usage count
    3. Name (alphabetical)

### 3) Variable placeholders support
- Added placeholder parsing with:
  - `/\{\{\s*([a-zA-Z0-9_-]+)\s*\}\}/g`
- Added variable input modal before insert when placeholders exist
- Added render step to replace `{{variable}}` with user-entered values

### 4) Prompt insertion flow
- Added composer detection for textarea/contenteditable inputs
- Added insertion logic that appends to existing text with spacing
- Dispatches UI events (`input` and `change`) to keep Claude UI in sync
- Shows user-facing alerts for insertion success/failure paths

### 5) Top-bar action button + picker modal
- Added “Prompt templates” top-bar button
- Added searchable picker modal with per-template actions:
  - Insert
  - Edit
  - Delete
- Updated button ordering in `content/helpers/claude-styles.js`:
  - Added `prompt-templates-button` to `ButtonBar.BUTTON_PRIORITY`

### 6) Settings page template manager
- Added settings-page injection for template management UI
- Includes:
  - New template creation
  - Search
  - Edit/Delete from list
- Uses same polling/injection style as existing settings integrations

### 7) Manifest wiring (all targets)
- Updated:
  - `manifest_chrome.json`
  - `manifest_firefox.json`
  - `manifest_electron.json`
- Added `content/isolated/prompt-templates.js` to isolated content scripts

### 8) UX polish fix requested during testing
- Updated insert behavior so that:
  - Clicking **Insert** from the template picker now automatically closes that picker modal after successful insertion.

## Notes
- Lint check was run on modified files and returned no linter errors.
- Plan file was not modified.
