### PR TITLE
fix: Handle a GDPR export that resolves to the archive, not a manifest

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,8 @@ if (chrome.action) {
 // storage.googleapis.com signed URLs — those are CORS-blocked from the page but allowed here via
 // host_permissions — fetching the manifest JSON and unzipping each batch ZIP with JSZip.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-	// Fetch a (CORS-restricted) GCS signed URL and return the parsed manifest JSON.
+	// Fetch a (CORS-restricted) GCS signed URL and report what came back: either the parsed
+	// manifest JSON, or a flag saying the URL is the export archive itself.
 	if (message.type === 'GDPR_FETCH_MANIFEST') {
 		(async () => {
 			try {
@@ -23,8 +24,39 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 				if (!response.ok) {
 					throw new Error(`Manifest download failed: ${response.status}`);
 				}
-				const manifest = JSON.parse(await response.text());
-				sendResponse({ success: true, manifest });
+
+				const reader = response.body.getReader();
+				const chunks = [];
+				const first = await reader.read();
+				if (first.value) chunks.push(first.value);
+
+				// Peek into the response to check whether we got a ZIP as a response instead of
+				// JSON. 'PK\x03\x04' is the local file header every ZIP starts with.
+				const head = first.value || new Uint8Array();
+				if (head[0] === 0x50 && head[1] === 0x4b && head[2] === 0x03 && head[3] === 0x04) {
+					await reader.cancel();
+					console.log('[Background] Export URL resolved to a ZIP, not a manifest');
+					sendResponse({ success: true, isZip: true });
+					return;
+				}
+
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					chunks.push(value);
+				}
+
+				const total = chunks.reduce((n, c) => n + c.length, 0);
+				const joined = new Uint8Array(total);
+				let offset = 0;
+				for (const c of chunks) { joined.set(c, offset); offset += c.length; }
+				const text = new TextDecoder().decode(joined);
+
+				try {
+					sendResponse({ success: true, manifest: JSON.parse(text) });
+				} catch (parseError) {
+					throw new Error(`Manifest is not JSON nor ZIP (${parseError.message}); response began: ${text.slice(0, 120)}`);
+				}
 			} catch (error) {
 				console.error('[Background] Manifest fetch failed:', error);
 				sendResponse({ success: false, error: error.message });
@@ -49,9 +81,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 						throw new Error(`Batch ${i} download failed: ${zipResponse.status}`);
 					}
 					const zip = await JSZip.loadAsync(await zipResponse.arrayBuffer());
-					const conversationsFile = zip.file('conversations.json');
+					// Matched by pattern rather than by exact name: a batch archive has it at the
+					// root, a whole-account export nests it under a directory.
+					const conversationsFile = zip.file(/(^|\/)conversations\.json$/i)[0];
 					if (!conversationsFile) {
-						throw new Error(`conversations.json not found in batch ${i}`);
+						const names = Object.keys(zip.files).slice(0, 10).join(', ');
+						throw new Error(`conversations.json not found in batch ${i} (archive contains: ${names || 'nothing'})`);
 					}
 					const batch = JSON.parse(await conversationsFile.async('text'));
 					conversations.push(...batch);

--- a/content/isolated/global-search.js
+++ b/content/isolated/global-search.js
@@ -405,12 +405,21 @@
 			throw new Error(`Manifest fetch failed: ${manifestResult ? manifestResult.error : 'no response'}`);
 		}
 
-		const dataFiles = (manifestResult.manifest.data_files || [])
+		// The signed URL either points at a manifest listing per-batch nonces, or straight at the
+		// archive. In the latter case there is nothing to resolve — the URL we hold is the only batch.
+		const zipUrls = [];
+		if (manifestResult.isZip) {
+			console.log('[QOL-GDPRExport] Export is a single archive, no manifest indirection');
+			zipUrls.push(manifestSignedUrl);
+		}
+
+		const dataFiles = manifestResult.isZip ? [] : (manifestResult.manifest.data_files || [])
 			.slice()
 			.sort((a, b) => a.batch_index - b.batch_index);
-		console.log('[QOL-GDPRExport] Manifest lists', dataFiles.length, 'batch file(s)');
+		if (!manifestResult.isZip) {
+			console.log('[QOL-GDPRExport] Manifest lists', dataFiles.length, 'batch file(s)');
+		}
 
-		const zipUrls = [];
 		for (const file of dataFiles) {
 			const batchNonce = file.export_url.split('/').pop();
 			let resolved = await resolveExportSignedUrl(orgId, batchNonce);
@@ -425,6 +434,10 @@
 				throw new Error(`Batch ${file.batch_index} unavailable: ${resolved.message || resolved.status}`);
 			}
 			zipUrls.push(resolved.signedUrl);
+		}
+
+		if (zipUrls.length === 0) {
+			throw new Error('The export contained no data files');
 		}
 
 		// Phase 4: Hand the ZIP URLs to the background to download, unzip and stream back.


### PR DESCRIPTION
The export signed URL can resolve either to a JSON manifest listing per-batch nonces, or directly to the export ZIP. Only the first was handled, so the second died in JSON.parse with "Unexpected token 'P', "PK"... is not valid JSON" — which reads like a corrupt download rather than a different response shape.

Peek at the first chunk for the ZIP local file header and cancel the read if it matches, so identifying the archive costs four bytes instead of the whole download. When it is a ZIP, use the URL we already hold as the only batch instead of resolving batch nonces that do not exist.

Also locate conversations.json by pattern, since a whole-account archive nests it under a directory, and report the archive contents when it is missing. A response that is neither JSON nor ZIP (an expired signed URL returns GCS XML) now quotes what actually arrived.