### PR TITLE
perf: Check message existence without decrypting every conversation

### DIFF
--- a/content/helpers/databases.js
+++ b/content/helpers/databases.js
@@ -301,6 +301,11 @@
 			}
 		}
 
+		// Existence check only, so it reads keys instead of decrypting every conversation.
+		async getAllMessageIds() {
+			return await db.messages.toCollection().primaryKeys();
+		}
+
 		async getAllMessages() {
 			const all = await db.messages.toArray();
 			const results = [];

--- a/content/isolated/global-search.js
+++ b/content/isolated/global-search.js
@@ -29,6 +29,7 @@
 
 		const storedMetadata = await searchDB.getAllMetadata();
 		const storedMap = new Map(storedMetadata.map(m => [m.uuid, m]));
+		const storedMessageIds = new Set(await searchDB.getAllMessageIds());
 
 		const toUpdate = [];
 		for (const conv of allConversations) {
@@ -36,17 +37,12 @@
 
 			if (!stored) {
 				toUpdate.push(conv);
-			} else {
-				// Check if messages exist
-				const messages = await searchDB.getMessages(conv.uuid);
-
-				if (messages === null) {
-					// Metadata exists but no messages - needs update
-					toUpdate.push(conv);
-				} else if (new Date(conv.updated_at) > new Date(stored.updated_at)) {
-					// Timestamp changed - needs update
-					toUpdate.push(conv);
-				}
+			} else if (!storedMessageIds.has(conv.uuid)) {
+				// Metadata exists but no messages - needs update
+				toUpdate.push(conv);
+			} else if (new Date(conv.updated_at) > new Date(stored.updated_at)) {
+				// Timestamp changed - needs update
+				toUpdate.push(conv);
 			}
 		}
 


### PR DESCRIPTION
That's the last PR for now - I tried to keep them small and self-contained for easier review, as these were the problems I hit.

getConversationsToUpdate() called getMessages() per conversation purely to test whether the row existed, and getMessages() runs an AES-GCM decrypt of that conversation's entire text. On a large history that is one full decrypt of the whole corpus on every sync, and the sync runs on each page load with text search on.

Read the primary keys once instead.